### PR TITLE
feat: print warning for invalid skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ skills/npm-*
 .github/skills
 .goose
 .opencode
+.crush

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import type { CommandOptions, NpmSkill, SymlinkResult } from './types.ts'
+import type { CommandOptions, InvalidSkill, NpmSkill, SymlinkResult } from './types.ts'
 import * as p from '@clack/prompts'
 import c from 'picocolors'
 import { GRAYS, isTTY, LOGO_LINES, RESET } from './constants.ts'
@@ -22,6 +22,22 @@ export function printSkills(skills: NpmSkill[]): void {
   for (const skill of skills) {
     console.log(`  ${c.green('●')} ${c.bold(skill.name)} ${c.dim(`from ${skill.packageName}`)}`)
     console.log(`    ${c.dim(skill.description)}`)
+  }
+}
+
+export function printInvalidSkills(invalidSkills: InvalidSkill[]): void {
+  if (isTTY) {
+    p.log.info('Invalid skills skipped:')
+    for (const invalid of invalidSkills) {
+      console.log(`  ${c.yellow('⚠')} ${c.dim(invalid.packageName)}/${invalid.skillName}`)
+      console.log(`    ${c.dim(`Error: ${invalid.error}`)}`)
+    }
+  }
+  else {
+    console.log('Invalid skills skipped:')
+    for (const invalid of invalidSkills) {
+      console.log(`  - ${invalid.packageName}/${invalid.skillName}: ${invalid.error}`)
+    }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,11 +65,30 @@ export interface ScanOptions {
   cwd?: string
 }
 
+export interface InvalidSkill {
+  /**
+   * NPM package name
+   */
+  packageName: string
+  /**
+   * Skill directory name
+   */
+  skillName: string
+  /**
+   * Error describing why the skill is invalid
+   */
+  error: string
+}
+
 export interface ScanResult {
   /**
    * Skills found in the scan
    */
   skills: NpmSkill[]
+  /**
+   * Invalid skills found in the scan
+   */
+  invalidSkills: InvalidSkill[]
   /**
    * Number of packages scanned
    */

--- a/src/utils/skills.ts
+++ b/src/utils/skills.ts
@@ -2,18 +2,18 @@ import { readFile, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import matter from 'gray-matter'
 
-export async function hasValidSkillMd(dir: string): Promise<{ valid: boolean, name?: string, description?: string }> {
+export async function hasValidSkillMd(dir: string): Promise<{ valid: boolean, name?: string, description?: string, error?: string }> {
   try {
     const skillMdPath = join(dir, 'SKILL.md')
     const stats = await stat(skillMdPath)
     if (!stats.isFile())
-      return { valid: false }
+      return { valid: false, error: 'not_a_file' }
 
     const content = await readFile(skillMdPath, 'utf-8')
     const { data } = matter(content)
 
     if (!data.name || !data.description)
-      return { valid: false }
+      return { valid: false, error: 'missing_fields' }
 
     return {
       valid: true,
@@ -22,6 +22,6 @@ export async function hasValidSkillMd(dir: string): Promise<{ valid: boolean, na
     }
   }
   catch {
-    return { valid: false }
+    return { valid: false, error: 'file_error' }
   }
 }


### PR DESCRIPTION
- [ x ] <- Keep this line and put an `x` between the brackts.

### Description

Add the `-verbose` command-line argument to display more details.
I added two incorrect skills to @slidev in local, example run:
<img width="946" height="550" alt="image" src="https://github.com/user-attachments/assets/5e62cc28-9be5-49f9-9c1c-f9afef5e26a4" />


### Linked Issues

Implement #2 

### Additional context

Is the current implementation reasonable? Or should we remove the parameters and display detailed information by default?
