### PR TITLE
fix: use absolute paths for Windows junction targets

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,12 @@
 import type { CommandOptions } from './types'
+import { platform } from 'node:os'
 import process from 'node:process'
 
 export const isTTY = process.stdout.isTTY
 
 export const isCI = Boolean(process.env.CI)
+
+export const isWindows = platform() === 'win32'
 
 export const DEFAULT_OPTIONS: CommandOptions = {
   source: 'node_modules',

--- a/src/symlink.ts
+++ b/src/symlink.ts
@@ -6,10 +6,10 @@ import type {
   SymlinkResult,
 } from './types'
 import { lstat, mkdir, readdir, readlink, rm, symlink } from 'node:fs/promises'
-import { platform } from 'node:os'
 import { dirname, join, relative, resolve } from 'node:path'
 import process from 'node:process'
 import { agents, detectInstalledAgents } from './agents'
+import { isWindows } from './constants'
 import { searchForWorkspaceRoot } from './utils'
 
 async function createSymlink(target: string, linkPath: string): Promise<boolean> {
@@ -59,11 +59,12 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
     const linkDir = dirname(linkPath)
     await mkdir(linkDir, { recursive: true })
 
-    // Create relative symlink
-    const relativePath = relative(linkDir, target)
-    const symlinkType = platform() === 'win32' ? 'junction' : undefined
+    const symlinkTarget = isWindows
+      ? resolvedTarget
+      : relative(linkDir, resolvedTarget)
+    const symlinkType = isWindows ? 'junction' : undefined
 
-    await symlink(relativePath, linkPath, symlinkType)
+    await symlink(symlinkTarget, linkPath, symlinkType)
     return true
   }
   catch {


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

Node.js resolves junction targets differently on Windows, so this fixes Windows junction creation by using absolute target paths.

### Linked Issues

fixes #30 
