### PR TITLE
feat: detect installed agents by command on PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ When `agents` is not set, `skills-npm` auto-detects which coding agents you use 
 - **Config directory** - an agent's home directory exists (e.g. `~/.cursor`, `~/.claude`).
 - **Installed command** - the agent's CLI is found on your `PATH` (e.g. `claude`, `codex`, `gemini`, `cursor-agent`). This catches agents that are installed but have not created their config directory yet.
 
-The command check is conservative: only agents with an unambiguous CLI name are probed, so generic names and GUI-only editors are matched by the directory check alone. Pass `--agents` (or set `agents` in the config) to bypass detection and target specific agents.
+The command check is conservative: only agents with an unambiguous CLI name are probed, so generic names and GUI-only editors are matched by the directory check alone.
+
+In an interactive terminal, the prompt lists **all** agents with the detected ones pre-selected, so you can add or remove any. Non-interactively (e.g. from the `prepare` hook), the detected set is used directly. Pass `--agents` (or set `agents` in the config) to bypass detection entirely.
 
 ## For Package Authors
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ Options:
   -v, --version           Display version
 ```
 
+## Agent detection
+
+When `agents` is not set, `skills-npm` auto-detects which coding agents you use and installs to those. Detection combines two signals:
+
+- **Config directory** - an agent's home directory exists (e.g. `~/.cursor`, `~/.claude`).
+- **Installed command** - the agent's CLI is found on your `PATH` (e.g. `claude`, `codex`, `gemini`, `cursor-agent`). This catches agents that are installed but have not created their config directory yet.
+
+The command check is conservative: only agents with an unambiguous CLI name are probed, so generic names and GUI-only editors are matched by the directory check alone. Pass `--agents` (or set `agents` in the config) to bypass detection and target specific agents.
+
 ## For Package Authors
 
 Include a `skills/` directory in your package:

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,11 +1,77 @@
 import type { AgentType } from './types'
+import type { CommandProbeOptions } from './utils/command'
 
 import { agents, detectInstalledAgents } from '../vendor/skills/src/agents'
+import { isCommandAvailable } from './utils/command'
 
 export { agents, detectInstalledAgents } from '../vendor/skills/src/agents'
 
+/**
+ * Conservative map of agent -> CLI command(s) that land on PATH when the tool is
+ * installed. Used to augment the vendored directory-based detection so agents
+ * that are installed but have not created their home directory yet are still
+ * found.
+ *
+ * Only agents with an unambiguous, definitely-a-CLI binary are included.
+ * Agents whose command name is generic (e.g. `pi`, `goose`, `vibe`, `cn`) or
+ * that are GUI-only (e.g. windsurf, trae, roo) are intentionally omitted; their
+ * directory-based detection is more reliable. Disambiguated long aliases are
+ * used where the short name collides (e.g. `kilocode`, not `kilo`).
+ */
+const AGENT_COMMANDS: Partial<Record<AgentType, string[]>> = {
+  'adal': ['adal'],
+  'amp': ['amp'],
+  'augment': ['auggie'],
+  'claude-code': ['claude'],
+  'cline': ['cline'],
+  'codebuddy': ['codebuddy'],
+  'codex': ['codex'],
+  'command-code': ['command-code', 'commandcode'],
+  'crush': ['crush'],
+  'cursor': ['cursor-agent'],
+  'deepagents': ['deepagents'],
+  'droid': ['droid'],
+  'gemini-cli': ['gemini'],
+  'github-copilot': ['copilot'],
+  'iflow-cli': ['iflow'],
+  'junie': ['junie'],
+  'kilo': ['kilocode'],
+  'kimi-cli': ['kimi'],
+  'kiro-cli': ['kiro'],
+  'kode': ['kode'],
+  'neovate': ['neovate'],
+  'openclaw': ['openclaw', 'clawdbot', 'moltbot'],
+  'opencode': ['opencode'],
+  'openhands': ['openhands'],
+  'pochi': ['pochi'],
+  'qwen-code': ['qwen'],
+}
+
+/**
+ * Detect installed agents by probing for their CLI command on PATH.
+ * Conservative and additive; see {@link AGENT_COMMANDS}.
+ */
+export async function detectAgentsByCommand(options?: CommandProbeOptions): Promise<AgentType[]> {
+  const entries = Object.entries(AGENT_COMMANDS) as [AgentType, string[]][]
+  const results = await Promise.all(
+    entries.map(async ([type, commands]) => {
+      const hits = await Promise.all(commands.map(command => isCommandAvailable(command, options)))
+      return { type, installed: hits.some(Boolean) }
+    }),
+  )
+  return results.filter(result => result.installed).map(result => result.type)
+}
+
+/**
+ * All detected agents: the union of the vendored directory-based detection and
+ * the command-on-PATH detection, deduplicated.
+ */
 export async function getDetectedAgents(): Promise<AgentType[]> {
-  return detectInstalledAgents()
+  const [byDir, byCommand] = await Promise.all([
+    detectInstalledAgents(),
+    detectAgentsByCommand(),
+  ])
+  return [...new Set([...byDir, ...byCommand])]
 }
 
 export function getAllAgentTypes(): AgentType[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -193,13 +193,12 @@ async function getTargetAgents(options: ResolvedOptions): Promise<AgentType[]> {
         ]
         const selected = await p.multiselect<string>({
           message: detectedAgents.length > 0
-            ? 'Select agents to install to (detected are pre-selected):'
+            ? 'Select agents to install to:'
             : 'No agents detected. Select agents to install to:',
           options: orderedAgents
             .map(agent => ({
               value: agent,
               label: agents[agent].displayName,
-              hint: detectedAgents.includes(agent) ? 'detected' : undefined,
             })),
           required: true,
           initialValues: detectedAgents.length > 0 ? detectedAgents : undefined,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import type { CAC } from 'cac'
 import type { AgentType, CommandOptions, NpmSkill, ResolvedOptions } from './types'
-import { realpathSync } from 'node:fs'
+import fs from 'node:fs'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import * as p from '@clack/prompts'
@@ -24,7 +24,7 @@ function isCliEntrypoint(): boolean {
   if (!entry)
     return false
   try {
-    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url))
+    return fs.realpathSync(entry) === fs.realpathSync(fileURLToPath(import.meta.url))
   }
   catch {
     return false

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import type { CAC } from 'cac'
 import type { AgentType, CommandOptions, NpmSkill, ResolvedOptions } from './types'
+import { realpathSync } from 'node:fs'
 import process from 'node:process'
+import { fileURLToPath } from 'node:url'
 import * as p from '@clack/prompts'
 import { cac } from 'cac'
 import c from 'picocolors'
@@ -16,6 +18,18 @@ import { cleanupStaleSkills, symlinkSkills } from './symlink'
 import { processSkills } from './utils/index'
 
 const cli: CAC = cac(name)
+
+function isCliEntrypoint(): boolean {
+  const entry = process.argv[1]
+  if (!entry)
+    return false
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url))
+  }
+  catch {
+    return false
+  }
+}
 
 try {
   cli
@@ -56,7 +70,12 @@ try {
 
   cli.help()
   cli.version(version)
-  cli.parse()
+
+  // Only run the CLI when executed directly (as the bin or via tsx), not when
+  // the module is imported (e.g. by the exports snapshot test), which would
+  // otherwise run a full sync as an import side effect.
+  if (isCliEntrypoint())
+    cli.parse()
 }
 catch (error) {
   const message = error instanceof Error ? error.message : 'Unknown error'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -179,17 +179,23 @@ async function getTargetAgents(options: ResolvedOptions): Promise<AgentType[]> {
     }
 
     if (isTTY) {
-      const agentOptions = detectedAgents.length > 0 ? detectedAgents : getAllAgentTypes()
+      const allAgents = getAllAgentTypes()
 
       if (options.yes) {
-        targetAgents = agentOptions
+        targetAgents = detectedAgents.length > 0 ? detectedAgents : allAgents
       }
       else {
+        // Offer every agent, with detected ones pre-selected and listed first,
+        // so you can both deselect detected agents and add undetected ones.
+        const orderedAgents = [
+          ...detectedAgents,
+          ...allAgents.filter(agent => !detectedAgents.includes(agent)),
+        ]
         const selected = await p.multiselect<string>({
           message: detectedAgents.length > 0
-            ? 'Select agents to install to:'
+            ? 'Select agents to install to (detected are pre-selected):'
             : 'No agents detected. Select agents to install to:',
-          options: agentOptions
+          options: orderedAgents
             .map(agent => ({
               value: agent,
               label: agents[agent].displayName,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -199,6 +199,7 @@ async function getTargetAgents(options: ResolvedOptions): Promise<AgentType[]> {
             .map(agent => ({
               value: agent,
               label: agents[agent].displayName,
+              hint: detectedAgents.includes(agent) ? 'detected' : undefined,
             })),
           required: true,
           initialValues: detectedAgents.length > 0 ? detectedAgents : undefined,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ function isCliEntrypoint(): boolean {
   if (!entry)
     return false
   try {
-    return fs.realpathSync(entry) === fs.realpathSync(fileURLToPath(import.meta.url))
+    return fs.realpathSync(entry) === fileURLToPath(import.meta.url)
   }
   catch {
     return false

--- a/src/symlink.ts
+++ b/src/symlink.ts
@@ -9,7 +9,7 @@ import { lstat, mkdir, readdir, readlink, rm, symlink } from 'node:fs/promises'
 import { platform } from 'node:os'
 import { dirname, join, relative, resolve } from 'node:path'
 import process from 'node:process'
-import { agents, detectInstalledAgents } from './agents'
+import { agents, getDetectedAgents } from './agents'
 import { searchForWorkspaceRoot } from './utils'
 
 async function createSymlink(target: string, linkPath: string): Promise<boolean> {
@@ -80,7 +80,7 @@ export async function symlinkSkill(skill: NpmSkill, options: SymlinkOptions = {}
   if (options.agents && options.agents.length > 0)
     targetAgents = options.agents as AgentType[]
   else
-    targetAgents = await detectInstalledAgents()
+    targetAgents = await getDetectedAgents()
 
   for (const agentType of targetAgents) {
     const agent = agents[agentType]
@@ -137,7 +137,7 @@ export async function cleanupStaleSkills(skills: NpmSkill[], options: SymlinkOpt
   if (options.agents && options.agents.length > 0)
     targetAgents = options.agents as AgentType[]
   else
-    targetAgents = await detectInstalledAgents()
+    targetAgents = await getDetectedAgents()
 
   for (const agentType of targetAgents) {
     const agent = agents[agentType]

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -1,0 +1,91 @@
+import { constants } from 'node:fs'
+import { access, stat } from 'node:fs/promises'
+import { delimiter, extname, join } from 'node:path'
+import process from 'node:process'
+
+export interface CommandProbeOptions {
+  /**
+   * Environment to read PATH/PATHEXT from. Defaults to `process.env`.
+   * Mainly a test seam.
+   */
+  env?: NodeJS.ProcessEnv
+  /**
+   * Platform to assume. Defaults to `process.platform`.
+   * Mainly a test seam, so Windows behavior can be exercised cross-platform.
+   */
+  platform?: NodeJS.Platform
+  /**
+   * Per-candidate executable check. Defaults to a `stat` + `access(X_OK)` probe.
+   * Mainly a test seam, so a synthetic file set can be supplied.
+   */
+  isExecutableFile?: (path: string) => Promise<boolean>
+}
+
+const DEFAULT_PATHEXT = '.EXE;.CMD;.BAT;.COM'
+
+const cache = new Map<string, boolean>()
+
+async function defaultIsExecutableFile(path: string, isWindows: boolean): Promise<boolean> {
+  try {
+    const stats = await stat(path) // follows symlinks (not lstat)
+    if (!stats.isFile())
+      return false // a directory on PATH carries the exec bit on POSIX; guard against it
+    if (isWindows)
+      return true // executability is decided by the extension; X_OK is a no-op on Windows
+    await access(path, constants.X_OK)
+    return true
+  }
+  catch {
+    return false // ENOENT / EACCES / etc.
+  }
+}
+
+/**
+ * Check whether `command` resolves to an executable on the system `PATH`.
+ *
+ * Zero-dependency, cross-platform scan: splits `PATH`, applies `PATHEXT` on
+ * Windows, and verifies each candidate is a real file (and executable on POSIX).
+ * Results are cached per command for the process lifetime, unless a test seam
+ * (`env`, `platform`, or `isExecutableFile`) is provided.
+ */
+export async function isCommandAvailable(
+  command: string,
+  options: CommandProbeOptions = {},
+): Promise<boolean> {
+  const injected = options.env !== undefined
+    || options.platform !== undefined
+    || options.isExecutableFile !== undefined
+
+  if (!injected && cache.has(command))
+    return cache.get(command)!
+
+  const env = options.env ?? process.env
+  const isWindows = (options.platform ?? process.platform) === 'win32'
+  const isExecutableFile = options.isExecutableFile
+    ?? (path => defaultIsExecutableFile(path, isWindows))
+
+  // Windows env var casing is preserved by Node, commonly `Path` / `Pathext`.
+  const pathValue = env.PATH ?? env.Path ?? ''
+  const dirs = pathValue.split(delimiter).filter(Boolean) // drop empty segments (cwd footgun)
+
+  const extensions = !isWindows || extname(command)
+    ? ['']
+    : (env.PATHEXT ?? env.Pathext ?? DEFAULT_PATHEXT).split(';').filter(Boolean)
+
+  let found = false
+  for (const dir of dirs) {
+    // probe extensions in parallel, but keep dir order for short-circuit semantics
+    const hits = await Promise.all(
+      extensions.map(extension => isExecutableFile(join(dir, command + extension))),
+    )
+    if (hits.some(Boolean)) {
+      found = true
+      break
+    }
+  }
+
+  if (!injected)
+    cache.set(command, found)
+
+  return found
+}

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -22,8 +22,6 @@ export interface CommandProbeOptions {
 
 const DEFAULT_PATHEXT = '.EXE;.CMD;.BAT;.COM'
 
-const cache = new Map<string, boolean>()
-
 async function defaultIsExecutableFile(filePath: string, isWindows: boolean): Promise<boolean> {
   try {
     const stats = await fs.stat(filePath) // follows symlinks (not lstat)
@@ -44,20 +42,11 @@ async function defaultIsExecutableFile(filePath: string, isWindows: boolean): Pr
  *
  * Zero-dependency, cross-platform scan: splits `PATH`, applies `PATHEXT` on
  * Windows, and verifies each candidate is a real file (and executable on POSIX).
- * Results are cached per command for the process lifetime, unless a test seam
- * (`env`, `platform`, or `isExecutableFile`) is provided.
  */
 export async function isCommandAvailable(
   command: string,
   options: CommandProbeOptions = {},
 ): Promise<boolean> {
-  const injected = options.env !== undefined
-    || options.platform !== undefined
-    || options.isExecutableFile !== undefined
-
-  if (!injected && cache.has(command))
-    return cache.get(command)!
-
   const env = options.env ?? process.env
   const isWindows = (options.platform ?? process.platform) === 'win32'
   const isExecutableFile = options.isExecutableFile
@@ -67,24 +56,20 @@ export async function isCommandAvailable(
   const pathValue = env.PATH ?? env.Path ?? ''
   const dirs = pathValue.split(path.delimiter).filter(Boolean) // drop empty segments (cwd footgun)
 
+  // On Windows, a bare name resolves via PATHEXT; otherwise (or when the command
+  // already has an extension) only the literal name is probed.
   const extensions = !isWindows || path.extname(command)
     ? ['']
     : (env.PATHEXT ?? env.Pathext ?? DEFAULT_PATHEXT).split(';').filter(Boolean)
 
-  let found = false
   for (const dir of dirs) {
     // probe extensions in parallel, but keep dir order for short-circuit semantics
     const hits = await Promise.all(
       extensions.map(extension => isExecutableFile(path.join(dir, command + extension))),
     )
-    if (hits.some(Boolean)) {
-      found = true
-      break
-    }
+    if (hits.some(Boolean))
+      return true
   }
 
-  if (!injected)
-    cache.set(command, found)
-
-  return found
+  return false
 }

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -2,21 +2,16 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 
+/**
+ * Options for {@link isCommandAvailable}. Every field is a dependency-injection
+ * seam for tests; production callers pass nothing.
+ */
 export interface CommandProbeOptions {
-  /**
-   * Environment to read PATH/PATHEXT from. Defaults to `process.env`.
-   * Mainly a test seam.
-   */
+  /** Environment to read PATH/PATHEXT from. Defaults to `process.env`. */
   env?: NodeJS.ProcessEnv
-  /**
-   * Platform to assume. Defaults to `process.platform`.
-   * Mainly a test seam, so Windows behavior can be exercised cross-platform.
-   */
+  /** Platform to assume. Defaults to `process.platform` (lets Windows behavior be tested cross-platform). */
   platform?: NodeJS.Platform
-  /**
-   * Per-candidate executable check. Defaults to a `stat` + `access(X_OK)` probe.
-   * Mainly a test seam, so a synthetic file set can be supplied.
-   */
+  /** Per-candidate executable check. Defaults to a `stat` + `access(X_OK)` probe. */
   isExecutableFile?: (filePath: string) => Promise<boolean>
 }
 

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -1,6 +1,5 @@
-import { constants } from 'node:fs'
-import { access, stat } from 'node:fs/promises'
-import { delimiter, extname, join } from 'node:path'
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import process from 'node:process'
 
 export interface CommandProbeOptions {
@@ -18,21 +17,21 @@ export interface CommandProbeOptions {
    * Per-candidate executable check. Defaults to a `stat` + `access(X_OK)` probe.
    * Mainly a test seam, so a synthetic file set can be supplied.
    */
-  isExecutableFile?: (path: string) => Promise<boolean>
+  isExecutableFile?: (filePath: string) => Promise<boolean>
 }
 
 const DEFAULT_PATHEXT = '.EXE;.CMD;.BAT;.COM'
 
 const cache = new Map<string, boolean>()
 
-async function defaultIsExecutableFile(path: string, isWindows: boolean): Promise<boolean> {
+async function defaultIsExecutableFile(filePath: string, isWindows: boolean): Promise<boolean> {
   try {
-    const stats = await stat(path) // follows symlinks (not lstat)
+    const stats = await fs.stat(filePath) // follows symlinks (not lstat)
     if (!stats.isFile())
       return false // a directory on PATH carries the exec bit on POSIX; guard against it
     if (isWindows)
       return true // executability is decided by the extension; X_OK is a no-op on Windows
-    await access(path, constants.X_OK)
+    await fs.access(filePath, fs.constants.X_OK)
     return true
   }
   catch {
@@ -62,13 +61,13 @@ export async function isCommandAvailable(
   const env = options.env ?? process.env
   const isWindows = (options.platform ?? process.platform) === 'win32'
   const isExecutableFile = options.isExecutableFile
-    ?? (path => defaultIsExecutableFile(path, isWindows))
+    ?? (filePath => defaultIsExecutableFile(filePath, isWindows))
 
   // Windows env var casing is preserved by Node, commonly `Path` / `Pathext`.
   const pathValue = env.PATH ?? env.Path ?? ''
-  const dirs = pathValue.split(delimiter).filter(Boolean) // drop empty segments (cwd footgun)
+  const dirs = pathValue.split(path.delimiter).filter(Boolean) // drop empty segments (cwd footgun)
 
-  const extensions = !isWindows || extname(command)
+  const extensions = !isWindows || path.extname(command)
     ? ['']
     : (env.PATHEXT ?? env.Pathext ?? DEFAULT_PATHEXT).split(';').filter(Boolean)
 
@@ -76,7 +75,7 @@ export async function isCommandAvailable(
   for (const dir of dirs) {
     // probe extensions in parallel, but keep dir order for short-circuit semantics
     const hits = await Promise.all(
-      extensions.map(extension => isExecutableFile(join(dir, command + extension))),
+      extensions.map(extension => isExecutableFile(path.join(dir, command + extension))),
     )
     if (hits.some(Boolean)) {
       found = true

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -6,12 +6,9 @@ import { describe, expect, it } from 'vitest'
 import { detectAgentsByCommand } from '../src/agents'
 import { isCommandAvailable } from '../src/utils/command'
 
-// Build PATH and expected candidate paths with the same node:path primitives the
-// implementation uses, so assertions hold on POSIX and Windows runners alike.
-function makePath(...dirs: string[]): string {
-  return dirs.join(delimiter)
-}
-
+// PATH strings and expected candidate paths are built with node:path's `join`
+// and `delimiter` (the same primitives the implementation uses), so assertions
+// hold on POSIX and Windows runners alike.
 function present(...paths: string[]): (p: string) => Promise<boolean> {
   const set = new Set(paths)
   return async p => set.has(p)
@@ -24,7 +21,7 @@ describe('isCommandAvailable', () => {
   it('finds a command present on PATH (POSIX)', async () => {
     const ok = await isCommandAvailable('claude', {
       platform: 'linux',
-      env: { PATH: makePath(BIN, BIN2) },
+      env: { PATH: [BIN, BIN2].join(delimiter) },
       isExecutableFile: present(join(BIN2, 'claude')),
     })
     expect(ok).toBe(true)
@@ -33,7 +30,7 @@ describe('isCommandAvailable', () => {
   it('returns false when the command is not present', async () => {
     const ok = await isCommandAvailable('claude', {
       platform: 'linux',
-      env: { PATH: makePath(BIN) },
+      env: { PATH: BIN },
       isExecutableFile: async () => false,
     })
     expect(ok).toBe(false)
@@ -52,7 +49,7 @@ describe('isCommandAvailable', () => {
     const probed: string[] = []
     const ok = await isCommandAvailable('claude', {
       platform: 'linux',
-      env: { PATH: makePath('', '', BIN, '') },
+      env: { PATH: ['', '', BIN, ''].join(delimiter) },
       isExecutableFile: async (p) => {
         probed.push(p)
         return false
@@ -117,7 +114,7 @@ describe('isCommandAvailable', () => {
 })
 
 describe('detectAgentsByCommand', () => {
-  const base = { platform: 'linux' as const, env: { PATH: makePath(BIN) } }
+  const base = { platform: 'linux' as const, env: { PATH: BIN } }
 
   it('maps present commands to their agent types', async () => {
     const detected = await detectAgentsByCommand({

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -1,6 +1,6 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import fs from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { delimiter, join } from 'node:path'
+import path from 'node:path'
 import process from 'node:process'
 import { describe, expect, it } from 'vitest'
 import { detectAgentsByCommand } from '../src/agents'
@@ -14,15 +14,15 @@ function present(...paths: string[]): (p: string) => Promise<boolean> {
   return async p => set.has(p)
 }
 
-const BIN = join('/', 'usr', 'bin')
-const BIN2 = join('/', 'usr', 'local', 'bin')
+const BIN = path.join('/', 'usr', 'bin')
+const BIN2 = path.join('/', 'usr', 'local', 'bin')
 
 describe('isCommandAvailable', () => {
   it('finds a command present on PATH (POSIX)', async () => {
     const ok = await isCommandAvailable('claude', {
       platform: 'linux',
-      env: { PATH: [BIN, BIN2].join(delimiter) },
-      isExecutableFile: present(join(BIN2, 'claude')),
+      env: { PATH: [BIN, BIN2].join(path.delimiter) },
+      isExecutableFile: present(path.join(BIN2, 'claude')),
     })
     expect(ok).toBe(true)
   })
@@ -49,14 +49,14 @@ describe('isCommandAvailable', () => {
     const probed: string[] = []
     const ok = await isCommandAvailable('claude', {
       platform: 'linux',
-      env: { PATH: ['', '', BIN, ''].join(delimiter) },
+      env: { PATH: ['', '', BIN, ''].join(path.delimiter) },
       isExecutableFile: async (p) => {
         probed.push(p)
         return false
       },
     })
     expect(ok).toBe(false)
-    expect(probed).toEqual([join(BIN, 'claude')])
+    expect(probed).toEqual([path.join(BIN, 'claude')])
   })
 
   // Note: a real Windows drive-letter dir (e.g. C:\bin) cannot be used here
@@ -67,7 +67,7 @@ describe('isCommandAvailable', () => {
     const ok = await isCommandAvailable('claude', {
       platform: 'win32',
       env: { Path: BIN, Pathext: '.EXE;.CMD;.BAT' },
-      isExecutableFile: present(join(BIN, 'claude.CMD')),
+      isExecutableFile: present(path.join(BIN, 'claude.CMD')),
     })
     expect(ok).toBe(true)
   })
@@ -76,7 +76,7 @@ describe('isCommandAvailable', () => {
     const ok = await isCommandAvailable('claude', {
       platform: 'win32',
       env: { Path: BIN, Pathext: '.EXE;.CMD;.BAT' },
-      isExecutableFile: present(join(BIN, 'claude')), // the extensionless file is not a PATHEXT candidate
+      isExecutableFile: present(path.join(BIN, 'claude')), // the extensionless file is not a PATHEXT candidate
     })
     expect(ok).toBe(false)
   })
@@ -85,7 +85,7 @@ describe('isCommandAvailable', () => {
     const ok = await isCommandAvailable('tool.exe', {
       platform: 'win32',
       env: { Path: BIN, Pathext: '.EXE;.CMD' },
-      isExecutableFile: present(join(BIN, 'tool.exe')),
+      isExecutableFile: present(path.join(BIN, 'tool.exe')),
     })
     expect(ok).toBe(true)
   })
@@ -93,13 +93,13 @@ describe('isCommandAvailable', () => {
   // Exercises the real defaultIsExecutableFile (stat + isFile guard + X_OK).
   // X_OK is a no-op on Windows, so this POSIX-specific check is skipped there.
   it.skipIf(process.platform === 'win32')('uses the real isFile and executable checks', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'skills-npm-cmd-'))
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'skills-npm-cmd-'))
     try {
-      await writeFile(join(dir, 'realcmd'), '#!/bin/sh\n')
-      await chmod(join(dir, 'realcmd'), 0o755)
-      await writeFile(join(dir, 'plainfile'), 'x')
-      await chmod(join(dir, 'plainfile'), 0o644)
-      await mkdir(join(dir, 'dircmd')) // a directory carries the exec bit on POSIX
+      await fs.writeFile(path.join(dir, 'realcmd'), '#!/bin/sh\n')
+      await fs.chmod(path.join(dir, 'realcmd'), 0o755)
+      await fs.writeFile(path.join(dir, 'plainfile'), 'x')
+      await fs.chmod(path.join(dir, 'plainfile'), 0o644)
+      await fs.mkdir(path.join(dir, 'dircmd')) // a directory carries the exec bit on POSIX
 
       const env = { PATH: dir }
       expect(await isCommandAvailable('realcmd', { platform: 'linux', env })).toBe(true)
@@ -108,7 +108,7 @@ describe('isCommandAvailable', () => {
       expect(await isCommandAvailable('missing', { platform: 'linux', env })).toBe(false)
     }
     finally {
-      await rm(dir, { recursive: true, force: true })
+      await fs.rm(dir, { recursive: true, force: true })
     }
   })
 })
@@ -119,7 +119,7 @@ describe('detectAgentsByCommand', () => {
   it('maps present commands to their agent types', async () => {
     const detected = await detectAgentsByCommand({
       ...base,
-      isExecutableFile: present(join(BIN, 'claude'), join(BIN, 'codex')),
+      isExecutableFile: present(path.join(BIN, 'claude'), path.join(BIN, 'codex')),
     })
     expect(detected).toContain('claude-code')
     expect(detected).toContain('codex')
@@ -129,13 +129,13 @@ describe('detectAgentsByCommand', () => {
   it('resolves cursor via cursor-agent, not the cursor IDE shim', async () => {
     const viaAgent = await detectAgentsByCommand({
       ...base,
-      isExecutableFile: present(join(BIN, 'cursor-agent')),
+      isExecutableFile: present(path.join(BIN, 'cursor-agent')),
     })
     expect(viaAgent).toContain('cursor')
 
     const viaShim = await detectAgentsByCommand({
       ...base,
-      isExecutableFile: present(join(BIN, 'cursor')),
+      isExecutableFile: present(path.join(BIN, 'cursor')),
     })
     expect(viaShim).not.toContain('cursor')
   })
@@ -143,7 +143,7 @@ describe('detectAgentsByCommand', () => {
   it('uses the disambiguated alias kilocode, not kilo', async () => {
     const detected = await detectAgentsByCommand({
       ...base,
-      isExecutableFile: present(join(BIN, 'kilocode')),
+      isExecutableFile: present(path.join(BIN, 'kilocode')),
     })
     expect(detected).toContain('kilo')
   })
@@ -152,10 +152,10 @@ describe('detectAgentsByCommand', () => {
     const detected = await detectAgentsByCommand({
       ...base,
       isExecutableFile: present(
-        join(BIN, 'pi'),
-        join(BIN, 'goose'),
-        join(BIN, 'code'),
-        join(BIN, 'vibe'),
+        path.join(BIN, 'pi'),
+        path.join(BIN, 'goose'),
+        path.join(BIN, 'code'),
+        path.join(BIN, 'vibe'),
       ),
     })
     expect(detected).toEqual([])

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -1,0 +1,174 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import process from 'node:process'
+import { describe, expect, it } from 'vitest'
+import { detectAgentsByCommand } from '../src/agents'
+import { isCommandAvailable } from '../src/utils/command'
+
+// Build PATH and expected candidate paths with the same node:path primitives the
+// implementation uses, so assertions hold on POSIX and Windows runners alike.
+function makePath(...dirs: string[]): string {
+  return dirs.join(delimiter)
+}
+
+function present(...paths: string[]): (p: string) => Promise<boolean> {
+  const set = new Set(paths)
+  return async p => set.has(p)
+}
+
+const BIN = join('/', 'usr', 'bin')
+const BIN2 = join('/', 'usr', 'local', 'bin')
+
+describe('isCommandAvailable', () => {
+  it('finds a command present on PATH (POSIX)', async () => {
+    const ok = await isCommandAvailable('claude', {
+      platform: 'linux',
+      env: { PATH: makePath(BIN, BIN2) },
+      isExecutableFile: present(join(BIN2, 'claude')),
+    })
+    expect(ok).toBe(true)
+  })
+
+  it('returns false when the command is not present', async () => {
+    const ok = await isCommandAvailable('claude', {
+      platform: 'linux',
+      env: { PATH: makePath(BIN) },
+      isExecutableFile: async () => false,
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('returns false for an empty PATH', async () => {
+    const ok = await isCommandAvailable('claude', {
+      platform: 'linux',
+      env: { PATH: '' },
+      isExecutableFile: async () => true,
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('drops empty PATH segments (no relative/cwd probe)', async () => {
+    const probed: string[] = []
+    const ok = await isCommandAvailable('claude', {
+      platform: 'linux',
+      env: { PATH: makePath('', '', BIN, '') },
+      isExecutableFile: async (p) => {
+        probed.push(p)
+        return false
+      },
+    })
+    expect(ok).toBe(false)
+    expect(probed).toEqual([join(BIN, 'claude')])
+  })
+
+  // Note: a real Windows drive-letter dir (e.g. C:\bin) cannot be used here
+  // because node:path.delimiter on a POSIX test host is ":", which would split
+  // the drive letter. platform: 'win32' is what drives the PATHEXT logic; the
+  // dir itself just needs to be free of the host delimiter.
+  it('reads Windows-cased Path/Pathext and resolves via PATHEXT', async () => {
+    const ok = await isCommandAvailable('claude', {
+      platform: 'win32',
+      env: { Path: BIN, Pathext: '.EXE;.CMD;.BAT' },
+      isExecutableFile: present(join(BIN, 'claude.CMD')),
+    })
+    expect(ok).toBe(true)
+  })
+
+  it('does not match a bare extensionless name on Windows', async () => {
+    const ok = await isCommandAvailable('claude', {
+      platform: 'win32',
+      env: { Path: BIN, Pathext: '.EXE;.CMD;.BAT' },
+      isExecutableFile: present(join(BIN, 'claude')), // the extensionless file is not a PATHEXT candidate
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('honors a command that already includes an extension on Windows', async () => {
+    const ok = await isCommandAvailable('tool.exe', {
+      platform: 'win32',
+      env: { Path: BIN, Pathext: '.EXE;.CMD' },
+      isExecutableFile: present(join(BIN, 'tool.exe')),
+    })
+    expect(ok).toBe(true)
+  })
+
+  // Exercises the real defaultIsExecutableFile (stat + isFile guard + X_OK).
+  // X_OK is a no-op on Windows, so this POSIX-specific check is skipped there.
+  it.skipIf(process.platform === 'win32')('uses the real isFile and executable checks', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'skills-npm-cmd-'))
+    try {
+      await writeFile(join(dir, 'realcmd'), '#!/bin/sh\n')
+      await chmod(join(dir, 'realcmd'), 0o755)
+      await writeFile(join(dir, 'plainfile'), 'x')
+      await chmod(join(dir, 'plainfile'), 0o644)
+      await mkdir(join(dir, 'dircmd')) // a directory carries the exec bit on POSIX
+
+      const env = { PATH: dir }
+      expect(await isCommandAvailable('realcmd', { platform: 'linux', env })).toBe(true)
+      expect(await isCommandAvailable('plainfile', { platform: 'linux', env })).toBe(false)
+      expect(await isCommandAvailable('dircmd', { platform: 'linux', env })).toBe(false)
+      expect(await isCommandAvailable('missing', { platform: 'linux', env })).toBe(false)
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('detectAgentsByCommand', () => {
+  const base = { platform: 'linux' as const, env: { PATH: makePath(BIN) } }
+
+  it('maps present commands to their agent types', async () => {
+    const detected = await detectAgentsByCommand({
+      ...base,
+      isExecutableFile: present(join(BIN, 'claude'), join(BIN, 'codex')),
+    })
+    expect(detected).toContain('claude-code')
+    expect(detected).toContain('codex')
+    expect(detected).not.toContain('cursor')
+  })
+
+  it('resolves cursor via cursor-agent, not the cursor IDE shim', async () => {
+    const viaAgent = await detectAgentsByCommand({
+      ...base,
+      isExecutableFile: present(join(BIN, 'cursor-agent')),
+    })
+    expect(viaAgent).toContain('cursor')
+
+    const viaShim = await detectAgentsByCommand({
+      ...base,
+      isExecutableFile: present(join(BIN, 'cursor')),
+    })
+    expect(viaShim).not.toContain('cursor')
+  })
+
+  it('uses the disambiguated alias kilocode, not kilo', async () => {
+    const detected = await detectAgentsByCommand({
+      ...base,
+      isExecutableFile: present(join(BIN, 'kilocode')),
+    })
+    expect(detected).toContain('kilo')
+  })
+
+  it('ignores generic command names that are intentionally unmapped', async () => {
+    const detected = await detectAgentsByCommand({
+      ...base,
+      isExecutableFile: present(
+        join(BIN, 'pi'),
+        join(BIN, 'goose'),
+        join(BIN, 'code'),
+        join(BIN, 'vibe'),
+      ),
+    })
+    expect(detected).toEqual([])
+  })
+
+  it('returns nothing when no mapped commands are present', async () => {
+    const detected = await detectAgentsByCommand({
+      ...base,
+      isExecutableFile: async () => false,
+    })
+    expect(detected).toEqual([])
+  })
+})

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -14,8 +14,8 @@ function present(...paths: string[]): (p: string) => Promise<boolean> {
   return async p => set.has(p)
 }
 
-const BIN = path.join('/', 'usr', 'bin')
-const BIN2 = path.join('/', 'usr', 'local', 'bin')
+const BIN = '/usr/bin'
+const BIN2 = '/usr/local/bin'
 
 describe('isCommandAvailable', () => {
   it('finds a command present on PATH (POSIX)', async () => {

--- a/test/exports/skills-npm.yaml
+++ b/test/exports/skills-npm.yaml
@@ -3,6 +3,7 @@
   cleanupStaleSkills: function
   createTargetName: function
   defineConfig: function
+  detectAgentsByCommand: function
   detectInstalledAgents: function
   filterSkills: function
   getAllAgentTypes: function


### PR DESCRIPTION
## Problem

When `agents` is not set, `skills-npm` auto-detects where to install by checking for each agent's config directory (e.g. `~/.cursor`, `~/.claude`). That misses agents that are installed but have not created their config directory yet - a freshly installed CLI, a clean machine, or an ephemeral dev container - so skills silently install to nothing for those agents.

## Changes

Augments directory-based detection with a command-on-PATH check. `getDetectedAgents()` now returns the union of:

- the existing vendored directory detection, and
- a new check for whether an agent's CLI is on `PATH` (e.g. `claude`, `codex`, `gemini`, `cursor-agent`).

The command map is deliberately conservative: only agents with an unambiguous, definitely-a-CLI binary are probed. Generic names (`pi`, `goose`, `vibe`, `cn`) and GUI-only editors (windsurf, trae, roo) are left to the directory check, and disambiguated long aliases are used where the short name collides (`kilocode`, not `kilo`; `cursor-agent`, not `cursor`).

The PATH check is a zero-dependency, cross-platform scan: it splits `PATH`, applies `PATHEXT` on Windows, verifies each candidate is a real executable file (`stat().isFile()` plus `access(X_OK)` on POSIX), handles `Path`/`Pathext` casing on Windows, and caches per command. `--agents` (or `agents` in config) still bypasses detection entirely.

New tests cover the PATH scan (POSIX, simulated Windows, and a real-filesystem `isFile`/executable check) and the agent mapping.

## Note for reviewers

This also includes the same `isCliEntrypoint` guard as #35. The exports snapshot test imports the `./cli` entry, which runs `cli.parse()` at module load; with command detection added, that import-time run reliably calls `process.exit` in CI (where no agents are present) and fails the suite. The guard makes the CLI run only when executed as the bin (or via tsx), never when imported. Both PRs touch `src/cli.ts` identically there, so whichever lands second drops that hunk on rebase.
